### PR TITLE
Added informative information about bad patches.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /*
 !/src
 !build.gradle
-!*.project
+.project
 !/gradle
 !gradlew
 !gradlew.bat

--- a/src/main/java/iodine/Main.java
+++ b/src/main/java/iodine/Main.java
@@ -119,9 +119,14 @@ public class Main {
                 return;
             }
             System.out.println("Applying patches...");
-            patchService.applyPatches();
-            System.out.println("Patches applied!");
+            boolean allApplied = patchService.applyPatches();
+            if (allApplied) {
+            	System.out.println("Patches applied!");
+            } else {
+            	System.out.println("Patches applied. But one or more failed.");
+            }
             return;
+            
         }
         if (!mainDir.exists()) mainDir.mkdir();
         File srcMainJava = new File(mainDir, "src/main/java");


### PR DESCRIPTION
Also fixed it crashing when one was encountered.

On a side note I have no idea when the gitignore keeps the .project file from eclipse.... 

A reference to the new way vs the old way (Used in Capiscum). New way: https://pastebin.com/aucJd2XT Old way: https://pastebin.com/jLe6F4SK